### PR TITLE
feat: implement progress data model

### DIFF
--- a/crates/guild-core/src/config.rs
+++ b/crates/guild-core/src/config.rs
@@ -112,6 +112,7 @@ mod tests {
 
     #[test]
     fn test_guild_dir_resolves_with_home_env() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let original_home = std::env::var("HOME").ok();
 
         unsafe {
@@ -139,6 +140,7 @@ mod tests {
 
     #[test]
     fn test_load_from_default_path() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let original_home = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         let mock_home = dir.path();

--- a/crates/guild-core/src/data.rs
+++ b/crates/guild-core/src/data.rs
@@ -1,4 +1,6 @@
+use crate::{GuildError, config::GuildConfig};
 use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
 
 /// Apprentice profile — stored in `~/.guild/data/profile.toml`
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +47,60 @@ pub struct Progress {
     pub checkpoints: Vec<Checkpoint>,
 }
 
+impl Progress {
+    fn path() -> PathBuf {
+        GuildConfig::guild_dir().join("data").join("progress.toml")
+    }
+
+    /// Load the progress registry from `~/.guild/data/progress.toml`.
+    /// Returns an empty progress structure if the file does not exist.
+    pub fn load() -> Result<Self, GuildError> {
+        let path = Self::path();
+        if !path.exists() {
+            return Ok(Self {
+                checkpoints: Vec::new(),
+            });
+        }
+        let content =
+            fs::read_to_string(&path).map_err(|_| GuildError::DataError { path: path.clone() })?;
+        let progress: Self = toml::from_str(&content)?;
+        Ok(progress)
+    }
+
+    /// Save the progress to `~/.guild/data/progress.toml`.
+    pub fn save(&self) -> Result<(), GuildError> {
+        let path = Self::path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content =
+            toml::to_string(self).map_err(|e| GuildError::SerializeError(e.to_string()))?;
+        fs::write(&path, content)?;
+        Ok(())
+    }
+
+    /// Mark a checkpoint as completed (case-insensitive).
+    /// Returns an error if the checkpoint ID is not found.
+    pub fn complete_checkpoint(&mut self, id: &str) -> Result<(), GuildError> {
+        let id_lower = id.trim().to_lowercase();
+        if let Some(checkpoint) = self
+            .checkpoints
+            .iter_mut()
+            .find(|c| c.id.trim().to_lowercase() == id_lower)
+        {
+            checkpoint.completed = true;
+            Ok(())
+        } else {
+            Err(GuildError::CheckpointNotFound(id.to_string()))
+        }
+    }
+
+    /// Return the first incomplete checkpoint in the curriculum sequence.
+    pub fn next_incomplete(&self) -> Option<&Checkpoint> {
+        self.checkpoints.iter().find(|c| !c.completed)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checkpoint {
     pub id: String,
@@ -73,4 +129,135 @@ pub enum ReviewStatus {
     InReview,
     Returned,
     Accepted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn mock_home(dir: &std::path::Path) {
+        unsafe {
+            std::env::set_var("HOME", dir);
+        }
+    }
+
+    fn restore_home(original: Option<String>) {
+        if let Some(home) = original {
+            unsafe {
+                std::env::set_var("HOME", home);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    fn sample_checkpoint(id: &str, title: &str, completed: bool) -> Checkpoint {
+        Checkpoint {
+            id: id.to_string(),
+            title: title.to_string(),
+            completed,
+        }
+    }
+
+    #[test]
+    fn test_load_missing_returns_empty_progress() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let original = std::env::var("HOME").ok();
+        let dir = tempdir().unwrap();
+        mock_home(dir.path());
+
+        let progress = Progress::load().unwrap();
+        assert!(progress.checkpoints.is_empty());
+
+        restore_home(original);
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let original = std::env::var("HOME").ok();
+        let dir = tempdir().unwrap();
+        mock_home(dir.path());
+
+        let mut progress = Progress::load().unwrap();
+        progress
+            .checkpoints
+            .push(sample_checkpoint("id-1", "Title 1", false));
+        progress
+            .checkpoints
+            .push(sample_checkpoint("id-2", "Title 2", true));
+        progress.save().unwrap();
+
+        let loaded = Progress::load().unwrap();
+        assert_eq!(loaded.checkpoints.len(), 2);
+        assert_eq!(loaded.checkpoints[0].id, "id-1");
+        assert_eq!(loaded.checkpoints[0].title, "Title 1");
+        assert!(!loaded.checkpoints[0].completed);
+        assert!(loaded.checkpoints[1].completed);
+
+        restore_home(original);
+    }
+
+    #[test]
+    fn test_complete_checkpoint_success_case_insensitive() {
+        let mut progress = Progress {
+            checkpoints: vec![
+                sample_checkpoint("checkpoint-1", "Title 1", false),
+                sample_checkpoint("checkpoint-2", "Title 2", false),
+            ],
+        };
+
+        // Exact match
+        progress.complete_checkpoint("checkpoint-1").unwrap();
+        assert!(progress.checkpoints[0].completed);
+
+        // Case-insensitive & trimmed match
+        progress.complete_checkpoint("  CHECKPOINT-2  ").unwrap();
+        assert!(progress.checkpoints[1].completed);
+    }
+
+    #[test]
+    fn test_complete_checkpoint_not_found() {
+        let mut progress = Progress {
+            checkpoints: vec![sample_checkpoint("checkpoint-1", "Title 1", false)],
+        };
+
+        let res = progress.complete_checkpoint("nonexistent");
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            GuildError::CheckpointNotFound(id) => assert_eq!(id, "nonexistent"),
+            other => panic!("expected CheckpointNotFound, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_next_incomplete() {
+        let mut progress = Progress {
+            checkpoints: vec![
+                sample_checkpoint("checkpoint-1", "Title 1", true),
+                sample_checkpoint("checkpoint-2", "Title 2", false),
+                sample_checkpoint("checkpoint-3", "Title 3", false),
+            ],
+        };
+
+        // First incomplete is checkpoint-2
+        let next = progress.next_incomplete().unwrap();
+        assert_eq!(next.id, "checkpoint-2");
+
+        // Complete checkpoint-2
+        progress.complete_checkpoint("checkpoint-2").unwrap();
+
+        // First incomplete is now checkpoint-3
+        let next = progress.next_incomplete().unwrap();
+        assert_eq!(next.id, "checkpoint-3");
+
+        // Complete checkpoint-3
+        progress.complete_checkpoint("checkpoint-3").unwrap();
+
+        // No more incomplete checkpoints
+        assert!(progress.next_incomplete().is_none());
+    }
 }

--- a/crates/guild-core/src/error.rs
+++ b/crates/guild-core/src/error.rs
@@ -17,4 +17,10 @@ pub enum GuildError {
 
     #[error("crosslink command failed: {0}")]
     Crosslink(String),
+
+    #[error("failed to serialize data: {0}")]
+    SerializeError(String),
+
+    #[error("checkpoint with ID '{0}' not found")]
+    CheckpointNotFound(String),
 }

--- a/crates/guild-core/src/lib.rs
+++ b/crates/guild-core/src/lib.rs
@@ -6,3 +6,6 @@ pub mod output;
 
 pub use config::GuildConfig;
 pub use error::GuildError;
+
+#[cfg(test)]
+pub static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
Closes #11 : implement Progress data model read/write.

Added `Progress::load()`, `save()`, `complete_checkpoint()`, and `next_incomplete()`. Added `GuildError::CheckpointNotFound` variant for when an invalid ID is requested.

**Testing note:** Race conditions risk: for me Cargo compiled and ran tests from both  config.rs and data.rs  in parallel threads. Because they both read/write the same process-wide environment variable ( HOME ), the test in  config.rs mutated  HOME  at the exact same instant that the test in  data.rs  was trying to read it, causing the config test to look in the wrong directory and fail. **Package-wide** solution to race conditions: TEST_ENV_LOCK  inside  lib.rs.