### PR TITLE
fix: merge side effects

### DIFF
--- a/crates/guild-core/Cargo.toml
+++ b/crates/guild-core/Cargo.toml
@@ -11,8 +11,8 @@ serde = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }
 colored = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-serde_json = { workspace = true }
 

--- a/crates/guild-core/src/config.rs
+++ b/crates/guild-core/src/config.rs
@@ -76,10 +76,7 @@ fn dirs_or_home() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::tempdir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn mock_home(dir: &std::path::Path) {
         unsafe {
@@ -130,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_init_creates_directories_and_default_config() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -159,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_init_is_idempotent() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -188,7 +185,7 @@ handle = "bob"
 
     #[test]
     fn test_init_fails_if_path_is_blocked_by_file() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());

--- a/crates/guild-core/src/data.rs
+++ b/crates/guild-core/src/data.rs
@@ -328,6 +328,8 @@ pub enum ReviewStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
+    use std::io::Write;
     use std::sync::Mutex;
     use tempfile::tempdir;
 
@@ -356,6 +358,9 @@ mod tests {
             name: "Alice".to_string(),
             handle: "alice".to_string(),
             joined: "2025-01-01".to_string(),
+        }
+    }
+
     fn sample_project(name: &str, path: &str) -> Project {
         Project {
             name: name.to_string(),
@@ -383,12 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn test_save_and_load_roundtrip() {
-        let _guard = ENV_LOCK.lock().unwrap();
-    fn test_load_missing_returns_empty_reviews() {
-    fn test_load_missing_returns_empty_progress() {
-        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
-    fn test_load_missing_returns_empty_registry() {
+    fn test_profile_save_and_load_roundtrip() {
         let _guard1 = ENV_LOCK.lock().unwrap();
         let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
@@ -402,6 +402,18 @@ mod tests {
         assert_eq!(loaded.name, "Alice");
         assert_eq!(loaded.handle, "alice");
         assert_eq!(loaded.joined, "2025-01-01");
+
+        restore_home(original);
+    }
+
+    #[test]
+    fn test_load_missing_returns_empty_registry() {
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
+        let original = std::env::var("HOME").ok();
+        let dir = tempdir().unwrap();
+        mock_home(dir.path());
+
         let registry = ProjectRegistry::load().unwrap();
         assert!(registry.projects.is_empty());
         let history = ReviewHistory::load().unwrap();
@@ -414,7 +426,8 @@ mod tests {
 
     #[test]
     fn test_load_missing_file_returns_data_error() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -426,9 +439,14 @@ mod tests {
             GuildError::DataError { .. } => {}
             other => panic!("expected DataError, got: {:?}", other),
         }
-    fn test_save_and_load_roundtrip() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+
+        restore_home(original);
+    }
+
+    #[test]
+    fn test_registry_history_progress_roundtrip() {
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -452,6 +470,7 @@ mod tests {
         let p_b = loaded.find_project("PROJECT-B").unwrap();
         assert_eq!(p_b.name, "Project-B");
         assert_eq!(p_b.path, "./b");
+
         let mut history = ReviewHistory::load().unwrap();
         history.add_round(sample_round("Project-A", 1)).unwrap();
         history.add_round(sample_round("Project-B", 2)).unwrap();
@@ -463,6 +482,7 @@ mod tests {
         assert_eq!(loaded.reviews[0].round, 1);
         assert_eq!(loaded.reviews[1].project, "Project-B");
         assert_eq!(loaded.reviews[1].round, 2);
+
         let mut progress = Progress::load().unwrap();
         progress
             .checkpoints
@@ -484,7 +504,8 @@ mod tests {
 
     #[test]
     fn test_load_invalid_toml_returns_parse_error() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -507,7 +528,8 @@ mod tests {
 
     #[test]
     fn test_load_wrong_schema_returns_parse_error() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -530,7 +552,8 @@ mod tests {
 
     #[test]
     fn test_save_creates_data_directory() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard1 = ENV_LOCK.lock().unwrap();
+        let _guard2 = crate::TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var("HOME").ok();
         let dir = tempdir().unwrap();
         mock_home(dir.path());
@@ -546,6 +569,9 @@ mod tests {
         );
 
         restore_home(original);
+    }
+
+    #[test]
     fn test_add_project_success_and_trimming() {
         let mut registry = ProjectRegistry { projects: vec![] };
 


### PR DESCRIPTION
Recovery from issues with overlapping merges.

1. Fixed Broken Tests & Syntax Errors in  data.rs :
      • Cleaned up syntax errors and unclosed delimiters inside the unit tests module of data.rs.
      • Re-structured the bad merge hunks into distinct, clean unit tests:  test_profile_save_and_load_roundtrip  and test_registry_history_progress_roundtrip .
  2. Added Missing Dependency in  guild-core :
      • Moved  serde_json = { workspace = true }  from  [dev-dependencies]  to  [dependencies]  in Cargo.toml, resolving a compilation error in  crosslink.rs .
  3. Resolved Race Conditions in Environment Variables during Tests:
      • Replaced the local  ENV_LOCK  with the global  crate::TEST_ENV_LOCK  in config.rs for all tests modifying/mocking the  HOME environment variable. This ensures tests running concurrently do not step on each other's environment variables.
      • Removed the unused  std::sync::Mutex  import in  config.rs .
  4. Formatting & Lints:
      • Ran  cargo fmt  to align all code blocks.
      • Confirmed that  cargo clippy --all-targets  and  cargo fmt --check  run cleanly with zero errors/warnings, and all 37 unit tests pass.